### PR TITLE
Fixed numpy-related warning issue.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.4
 commit = True
 tag = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ project = 'njsd'
 year = '2018'
 author = 'Dohoon Lee'
 copyright = '{0}, {1}'.format(year, author)
-version = release = '0.1.3'
+version = release = '0.1.4'
 
 pygments_style = 'trac'
 templates_path = ['.']

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def read(*names, **kwargs):
 
 setup(
     name='njsd',
-    version='0.1.3',
+    version='0.1.4',
     license='BSD 2-Clause License',
     description='Calculate Jensen-Shannon Divergence between two gene expression profiles to measure transcriptome-based intratumor heterogeneity(tITH).',
     author='Youngjune Park',

--- a/src/njsd/__init__.py
+++ b/src/njsd/__init__.py
@@ -1,12 +1,19 @@
 __version__ = '0.1.3'
 
-import numpy as np
+import logging
 
 import njsd.util as util
 import njsd.entropy as entropy
 
 
-def njsd_all(network, ref, query, file):
+logger = logging.getLogger('nJSD')
+formatter = logging.Formatter('[%(name)s %(levelname)s %(asctime)s] %(message)s')
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(formatter)
+logger.addHandler(stream_handler)
+
+
+def njsd_all(network, ref, query, file, verbose=True):
     """Compute transcriptome-wide nJSD between reference and query expression profiles.
     Attribute:
         network (str): File path to a network file.
@@ -23,14 +30,14 @@ def njsd_all(network, ref, query, file):
         print('nJSD_NT', 'nJSD_TA', 'tITH', sep='\t', file=outFile)
 
     normal_to_tumor_njsd = entropy.njsd(network=graph,
-                                     ref_gene_expression_dict=ref_gene_expression_dict,
-                                     query_gene_expression_dict=query_gene_expression_dict,
-                                     gene_set=gene_set_present)
-
-    tumor_to_ambiguous_njsd = entropy.njsd(network=graph,
-                                        ref_gene_expression_dict=maximally_ambiguous_gene_experession_dict,
+                                        ref_gene_expression_dict=ref_gene_expression_dict,
                                         query_gene_expression_dict=query_gene_expression_dict,
                                         gene_set=gene_set_present)
+
+    tumor_to_ambiguous_njsd = entropy.njsd(network=graph,
+                                           ref_gene_expression_dict=maximally_ambiguous_gene_experession_dict,
+                                           query_gene_expression_dict=query_gene_expression_dict,
+                                           gene_set=gene_set_present)
     tITH = normal_to_tumor_njsd / (normal_to_tumor_njsd + tumor_to_ambiguous_njsd)
 
     with open(file, 'a') as outFile:
@@ -38,7 +45,7 @@ def njsd_all(network, ref, query, file):
     return normal_to_tumor_njsd / (normal_to_tumor_njsd + tumor_to_ambiguous_njsd)
 
 
-def njsd_geneset(network, ref, query, gene_set, file):
+def njsd_geneset(network, ref, query, gene_set, file, verbose=True):
     """Compute gene set-specified nJSD between reference and query expression profiles.
     Attribute;
         network (str): File path to a network file.
@@ -51,20 +58,32 @@ def njsd_geneset(network, ref, query, gene_set, file):
     query_gene_expression_dict = util.parse_gene_expression(query, mean=False)
     group_gene_set_dict = util.parse_gene_set(gene_set)
     maximally_ambiguous_gene_experession_dict = util.get_maximally_ambiguous_network(query_gene_expression_dict)
+    gene_set_present = set(query_gene_expression_dict.keys())
 
     with open(file, 'w') as outFile:
         print('Gene_set_ID', 'nJSD_NT', 'nJSD_TA', 'tITH', sep='\t', file=outFile)
 
     for group, gene_set in group_gene_set_dict.items():
-        normal_to_tumor_njsd = entropy.njsd(network=graph,
-                                         ref_gene_expression_dict=ref_gene_expression_dict,
-                                         query_gene_expression_dict=query_gene_expression_dict,
-                                         gene_set=gene_set)
+        gene_set_to_be_analyzed = gene_set.intersection(gene_set_present)
+        # If no genes are available for the group, just ignore it.
+        if len(gene_set_to_be_analyzed) == 0:
+            logger.warning('%s has no genes available for analysis. Ignoring the group.' % group)
+            continue
 
-        tumor_to_ambiguous_njsd = entropy.njsd(network=graph,
-                                            ref_gene_expression_dict=maximally_ambiguous_gene_experession_dict,
+        # If every gene has a single neighbor, just ignore it.
+        if all([graph.degree(gene) == 1 for gene in gene_set_to_be_analyzed]):
+            logger.warning('%s has no genes with enough neighbors. Ignoring the group.' % group)
+            continue
+
+        normal_to_tumor_njsd = entropy.njsd(network=graph,
+                                            ref_gene_expression_dict=ref_gene_expression_dict,
                                             query_gene_expression_dict=query_gene_expression_dict,
                                             gene_set=gene_set)
+
+        tumor_to_ambiguous_njsd = entropy.njsd(network=graph,
+                                               ref_gene_expression_dict=maximally_ambiguous_gene_experession_dict,
+                                               query_gene_expression_dict=query_gene_expression_dict,
+                                               gene_set=gene_set)
 
         tITH = normal_to_tumor_njsd / (normal_to_tumor_njsd + tumor_to_ambiguous_njsd)
         with open(file, 'a') as outFile:

--- a/src/njsd/__init__.py
+++ b/src/njsd/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __version__ = '0.1.3'
 
 import logging

--- a/src/njsd/__init__.py
+++ b/src/njsd/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 import logging
 

--- a/src/njsd/entropy.py
+++ b/src/njsd/entropy.py
@@ -1,5 +1,5 @@
-import networkx as nx
 import numpy as np
+
 
 def find_neighbors(graph, node):
     """Find neighbors of a node in a graph.
@@ -66,10 +66,6 @@ def njsd(network, ref_gene_expression_dict, query_gene_expression_dict, gene_set
             continue
 
         neighbors = find_neighbors(network, gene)
-
-        # If there is no neighbor for the gene, just ignore it.
-        if len(neighbors) == 0:
-            continue
 
         query_expression_vec = get_neighbor_expression_vector(neighbors, query_gene_expression_dict)
         ref_expression_vec = get_neighbor_expression_vector(neighbors, ref_gene_expression_dict)


### PR DESCRIPTION
Nice warning message will be shown when a group with no gene for analysis is filtered, and the package is updated to be compatible with Python 2, though Python 3 is recommended.